### PR TITLE
Mesh predeformation enhancements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [project.scripts]
 fsipy-mesh = "fsipy.automatedPreprocessing.automated_preprocessing:main_meshing"
+fsipy-predeform-mesh = "fsipy.automatedPreprocessing.predeform_mesh:main"
 
 [project.optional-dependencies]
 test = [

--- a/src/fsipy/__init__.py
+++ b/src/fsipy/__init__.py
@@ -7,6 +7,7 @@ from importlib.metadata import metadata
 # Imports from pre-processing
 from .automatedPreprocessing import automated_preprocessing
 from .automatedPreprocessing import preprocessing_common
+from .automatedPreprocessing import predeform_mesh
 # Imports from simulation scripts
 #from .simulation import Aneurysm
 #from .simulation import AVF
@@ -25,6 +26,7 @@ __all__ = [
 #    "postprocessing_common",
     "automated_preprocessing",
     "preprocessing_common",
+    "predeform_mesh",
 #    "Aneurysm",
 #    "AVF",
 #    "Stenosis",

--- a/src/fsipy/automatedPreprocessing/__init__.py
+++ b/src/fsipy/automatedPreprocessing/__init__.py
@@ -1,2 +1,3 @@
 from . import automated_preprocessing
 from . import preprocessing_common
+from . import predeform_mesh

--- a/src/fsipy/automatedPreprocessing/predeform_mesh.py
+++ b/src/fsipy/automatedPreprocessing/predeform_mesh.py
@@ -15,6 +15,7 @@ import argparse
 import h5py
 from pathlib import Path
 
+
 def parse_arguments() -> argparse.Namespace:
     """
     Parse command line arguments.
@@ -27,6 +28,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument('--mesh-path', type=str, default=None,
                         help="Path to the mesh file (default: <folder_path>/Checkpoint/mesh.h5)")
     return parser.parse_args()
+
 
 def predeform_mesh(folder_path: str, mesh_path: str) -> None:
     """
@@ -66,6 +68,7 @@ def predeform_mesh(folder_path: str, mesh_path: str) -> None:
 
     print("Mesh predeformed successfully!")
 
+
 def main() -> None:
     """
     Main function for parsing arguments and predeforming the mesh.
@@ -75,6 +78,7 @@ def main() -> None:
     """
     args = parse_arguments()
     predeform_mesh(args.folder, args.mesh_path)
+
 
 if __name__ == '__main__':
     main()

--- a/src/fsipy/automatedPreprocessing/predeform_mesh.py
+++ b/src/fsipy/automatedPreprocessing/predeform_mesh.py
@@ -18,11 +18,15 @@ from pathlib import Path
 def parse_arguments():
     parser = ArgumentParser(description=__doc__, formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument('--folder', type=str, help="Path to simulation results")
+    parser.add_argument('--mesh-path', type=str, default=None,
+                        help="Path to the mesh file (default: <folder_path>/Checkpoint/mesh.h5)")
     return parser.parse_args()
 
-def predeform_mesh(folder_path):
+def predeform_mesh(folder_path, mesh_path):
     # Path to the displacement file
     disp_path = Path(folder_path) / "Visualization" / "displacement.h5"
+    if mesh_path is None:
+        mesh_path = Path(folder_path) / "Checkpoint" / "mesh.h5"
     mesh_path = Path(folder_path) / "Checkpoint" / "mesh.h5"
     predeformed_mesh_path = mesh_path.with_name(mesh_path.stem + "_predeformed.h5")
 
@@ -45,7 +49,7 @@ def predeform_mesh(folder_path):
 
 def main():
     args = parse_arguments()
-    predeform_mesh(args.folder)
+    predeform_mesh(args.folder, args.mesh_path)
 
 if __name__ == '__main__':
     main()

--- a/src/fsipy/automatedPreprocessing/predeform_mesh.py
+++ b/src/fsipy/automatedPreprocessing/predeform_mesh.py
@@ -23,11 +23,7 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def predeform_mesh():
-    args = parse_arguments()
-
-    folder_path = args.folder
-
+def predeform_mesh(folder_path):
     # Path to the displacement file
     disp_path = path.join(folder_path, "Visualization", "displacement.h5")
     mesh_path = path.join(folder_path, "Checkpoint", "mesh.h5")
@@ -57,5 +53,10 @@ def predeform_mesh():
     vectorData.close()
 
 
+def main():
+    args = parse_arguments()
+    predeform_mesh(args.folder)
+
+
 if __name__ == '__main__':
-    predeform_mesh()
+    main()

--- a/src/fsipy/automatedPreprocessing/predeform_mesh.py
+++ b/src/fsipy/automatedPreprocessing/predeform_mesh.py
@@ -15,19 +15,34 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import h5py
 from pathlib import Path
 
-def parse_arguments():
+def parse_arguments() -> argparse.Namespace:
+    """
+    Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments.
+    """
     parser = ArgumentParser(description=__doc__, formatter_class=RawDescriptionHelpFormatter)
-    parser.add_argument('--folder', type=str, help="Path to simulation results")
+    parser.add_argument('--folder', type=str, required=True, help="Path to simulation results")
     parser.add_argument('--mesh-path', type=str, default=None,
                         help="Path to the mesh file (default: <folder_path>/Checkpoint/mesh.h5)")
     return parser.parse_args()
 
-def predeform_mesh(folder_path, mesh_path):
+def predeform_mesh(folder_path: str, mesh_path: str) -> None:
+    """
+    Predeform the mesh for FSI simulation.
+
+    Args:
+        folder_path (str): Path to the simulation results folder.
+        mesh_path (str): Path to the mesh file.
+
+    Returns:
+        None
+    """
     # Path to the displacement file
     disp_path = Path(folder_path) / "Visualization" / "displacement.h5"
     if mesh_path is None:
         mesh_path = Path(folder_path) / "Checkpoint" / "mesh.h5"
-    mesh_path = Path(folder_path) / "Checkpoint" / "mesh.h5"
     predeformed_mesh_path = mesh_path.with_name(mesh_path.stem + "_predeformed.h5")
 
     # Read the displacement file and get the displacement from the last time step
@@ -47,7 +62,13 @@ def predeform_mesh(folder_path, mesh_path):
             modified = vectorData[ArrayName][:, :] + disp_array * scaleFactor
             vectorArray[...] = modified
 
-def main():
+def main() -> None:
+    """
+    Main function for parsing arguments and predeforming the mesh.
+
+    Returns:
+        None
+    """
     args = parse_arguments()
     predeform_mesh(args.folder, args.mesh_path)
 

--- a/src/fsipy/automatedPreprocessing/predeform_mesh.py
+++ b/src/fsipy/automatedPreprocessing/predeform_mesh.py
@@ -11,7 +11,7 @@ displacement to the original mesh, this script generates a predeformed mesh for
 subsequent simulation steps.
 """
 
-from argparse import ArgumentParser, RawDescriptionHelpFormatter
+import argparse
 import h5py
 from pathlib import Path
 
@@ -22,7 +22,7 @@ def parse_arguments() -> argparse.Namespace:
     Returns:
         argparse.Namespace: Parsed command-line arguments.
     """
-    parser = ArgumentParser(description=__doc__, formatter_class=RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--folder', type=str, required=True, help="Path to simulation results")
     parser.add_argument('--mesh-path', type=str, default=None,
                         help="Path to the mesh file (default: <folder_path>/Checkpoint/mesh.h5)")
@@ -39,6 +39,8 @@ def predeform_mesh(folder_path: str, mesh_path: str) -> None:
     Returns:
         None
     """
+    print("Predeforming mesh...")
+
     # Path to the displacement file
     disp_path = Path(folder_path) / "Visualization" / "displacement.h5"
     if mesh_path is None:
@@ -61,6 +63,8 @@ def predeform_mesh(folder_path: str, mesh_path: str) -> None:
             vectorArray = vectorData[ArrayName]
             modified = vectorData[ArrayName][:, :] + disp_array * scaleFactor
             vectorArray[...] = modified
+
+    print("Mesh predeformed successfully!")
 
 def main() -> None:
     """

--- a/src/fsipy/automatedPreprocessing/predeform_mesh.py
+++ b/src/fsipy/automatedPreprocessing/predeform_mesh.py
@@ -4,23 +4,29 @@
 # PURPOSE.
 
 """
-This script is used to predeform the mesh for the FSI simulation.
-It is assumed that the simulation has already been run and the displacement is available as the displacement.h5 file.
-By applying the reverse of the displacement to the original mesh, we can obtain the predeformed mesh.
+This script is used to predeform the mesh for an FSI simulation. It assumes
+that the simulation has already been executed, and the displacement information
+is available in the 'displacement.h5' file. By applying the reverse of the
+displacement to the original mesh, this script generates a predeformed mesh for
+subsequent simulation steps.
 """
 
-
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from os import path
 import h5py
 from shutil import copyfile
 
 
-def predeform_mesh():
-
-    parser = ArgumentParser()
+def parse_arguments():
+    parser = ArgumentParser(description=__doc__, formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument('--folder', type=str, help="Path to simulation results")
-    folder_path = parser.parse_args().folder
+    return parser.parse_args()
+
+
+def predeform_mesh():
+    args = parse_arguments()
+
+    folder_path = args.folder
 
     # Path to the displacement file
     disp_path = path.join(folder_path, "Visualization", "displacement.h5")

--- a/src/fsipy/automatedPreprocessing/predeform_mesh.py
+++ b/src/fsipy/automatedPreprocessing/predeform_mesh.py
@@ -27,16 +27,19 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument('--folder', type=str, required=True, help="Path to simulation results")
     parser.add_argument('--mesh-path', type=str, default=None,
                         help="Path to the mesh file (default: <folder_path>/Checkpoint/mesh.h5)")
+    parser.add_argument('--scale-factor', type=float, default=-1,
+                        help="Scale factor for mesh deformation (default: -1)")
     return parser.parse_args()
 
 
-def predeform_mesh(folder_path: str, mesh_path: str) -> None:
+def predeform_mesh(folder_path: str, mesh_path: str, scale_factor: float) -> None:
     """
     Predeform the mesh for FSI simulation.
 
     Args:
         folder_path (str): Path to the simulation results folder.
         mesh_path (str): Path to the mesh file.
+        scale_factor (float): Scale factor for mesh deformation.
 
     Returns:
         None
@@ -47,7 +50,10 @@ def predeform_mesh(folder_path: str, mesh_path: str) -> None:
     disp_path = Path(folder_path) / "Visualization" / "displacement.h5"
     if mesh_path is None:
         mesh_path = Path(folder_path) / "Checkpoint" / "mesh.h5"
-    predeformed_mesh_path = mesh_path.with_name(mesh_path.stem + "_predeformed.h5")
+    predeformed_mesh_path = Path(mesh_path).with_name(mesh_path.stem + "_predeformed.h5")
+
+    # Make a copy of the original mesh
+    predeformed_mesh_path.write_bytes(mesh_path.read_bytes())
 
     # Read the displacement file and get the displacement from the last time step
     with h5py.File(disp_path, "r") as vectorData:
@@ -56,14 +62,10 @@ def predeform_mesh(folder_path: str, mesh_path: str) -> None:
 
     # Open the new mesh file in read-write mode
     with h5py.File(predeformed_mesh_path, 'r+') as vectorData:
-        # We modify the original geometry by adding the reverse of the displacement
-        # Hence, scaleFactor = -1.0
-        scaleFactor = -1.0
-
         ArrayNames = ['mesh/coordinates', 'domains/coordinates', 'boundaries/coordinates']
         for ArrayName in ArrayNames:
             vectorArray = vectorData[ArrayName]
-            modified = vectorData[ArrayName][:, :] + disp_array * scaleFactor
+            modified = vectorData[ArrayName][:, :] + disp_array * scale_factor
             vectorArray[...] = modified
 
     print("Mesh predeformed successfully!")
@@ -77,7 +79,7 @@ def main() -> None:
         None
     """
     args = parse_arguments()
-    predeform_mesh(args.folder, args.mesh_path)
+    predeform_mesh(args.folder, args.mesh_path, args.scale_factor)
 
 
 if __name__ == '__main__':

--- a/src/fsipy/automatedPreprocessing/predeform_mesh.py
+++ b/src/fsipy/automatedPreprocessing/predeform_mesh.py
@@ -12,51 +12,40 @@ subsequent simulation steps.
 """
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
-from os import path
 import h5py
-from shutil import copyfile
-
+from pathlib import Path
 
 def parse_arguments():
     parser = ArgumentParser(description=__doc__, formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument('--folder', type=str, help="Path to simulation results")
     return parser.parse_args()
 
-
 def predeform_mesh(folder_path):
     # Path to the displacement file
-    disp_path = path.join(folder_path, "Visualization", "displacement.h5")
-    mesh_path = path.join(folder_path, "Checkpoint", "mesh.h5")
+    disp_path = Path(folder_path) / "Visualization" / "displacement.h5"
+    mesh_path = Path(folder_path) / "Checkpoint" / "mesh.h5"
+    predeformed_mesh_path = mesh_path.with_name(mesh_path.stem + "_predeformed.h5")
 
     # Read the displacement file and get the displacement from the last time step
-    vectorData = h5py.File(disp_path, "r")
-    number_of_datasets = len(vectorData["VisualisationVector"].keys())
-    disp_array = vectorData[f"VisualisationVector/{number_of_datasets - 1}"][:, :]
+    with h5py.File(disp_path, "r") as vectorData:
+        number_of_datasets = len(vectorData["VisualisationVector"].keys())
+        disp_array = vectorData[f"VisualisationVector/{number_of_datasets - 1}"][:, :]
 
-    # Create a copy of the mesh file with a new name
-    predeformed_mesh_path = mesh_path.replace(".h5", "_predeformed.h5")
-    copyfile(mesh_path, predeformed_mesh_path)
+    # Open the new mesh file in read-write mode
+    with h5py.File(predeformed_mesh_path, 'r+') as vectorData:
+        # We modify the original geometry by adding the reverse of the displacement
+        # Hence, scaleFactor = -1.0
+        scaleFactor = -1.0
 
-    # Open the new mesh file in append mode
-    vectorData = h5py.File(predeformed_mesh_path, 'a')
-
-    # We modify the original geometry by adding the reverse of the displacement
-    # Hence, scaleFactor = -1.0
-    scaleFactor = -1.0
-
-    ArrayNames = ['mesh/coordinates', 'domains/coordinates', 'boundaries/coordinates']
-    for ArrayName in ArrayNames:
-        vectorArray = vectorData[ArrayName]
-        modified = vectorData[ArrayName][:, :] + disp_array * scaleFactor
-        vectorArray[...] = modified
-
-    vectorData.close()
-
+        ArrayNames = ['mesh/coordinates', 'domains/coordinates', 'boundaries/coordinates']
+        for ArrayName in ArrayNames:
+            vectorArray = vectorData[ArrayName]
+            modified = vectorData[ArrayName][:, :] + disp_array * scaleFactor
+            vectorArray[...] = modified
 
 def main():
     args = parse_arguments()
     predeform_mesh(args.folder)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I have made some changes to the predeform mesh script:
* The script is now installed as `fsipy-predeform-mesh` when running `pip install`.
* Added `--help` option.
* Added a new optional command-line argument `--mesh-path` with a default value of `<folder_path>/Checkpoint/mesh.h5` to specify the path to the mesh file.
* Switched to use the `pathlib` library.
* Added docstrings and type hints to functions.
* Added print statements to provide informative feedback about the progress of the script and the result of the mesh predeformation.