### PR TITLE
Add VTU to XDMF mesh conversion using meshio

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pip
   - python >=3.8
   - git
+  - meshio
   - pip:
       - git+https://github.com/KVSlab/VaMPy.git
       - git+https://github.com/KVSlab/turtleFSI.git

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -20,7 +20,7 @@ from vampy.automatedPreprocessing.simulate import run_simulation
 from vampy.automatedPreprocessing.visualize import visualize_model
 
 from fsipy.automatedPreprocessing.preprocessing_common import generate_mesh, distance_to_spheres_solid_thickness, \
-    dist_sphere_spheres, convert_xml_mesh_to_hdf5, convert_vtu_mesh_to_xdmf
+    dist_sphere_spheres, convert_vtu_mesh_to_xdmf
 
 
 def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_factor, smoothing_iterations,

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -14,13 +14,13 @@ from morphman import get_uncapped_surface, write_polydata, get_parameters, vtk_c
 from vampy.automatedPreprocessing import ToolRepairSTL
 from vampy.automatedPreprocessing.preprocessing_common import read_polydata, get_centers_for_meshing, \
     dist_sphere_diam, dist_sphere_curvature, dist_sphere_constant, get_regions_to_refine, add_flow_extension, \
-    mesh_alternative, find_boundaries, compute_flow_rate, setup_model_network, \
+    write_mesh, mesh_alternative, find_boundaries, compute_flow_rate, setup_model_network, \
     radiusArrayName, scale_surface, get_furtest_surface_point, check_if_closed_surface
 from vampy.automatedPreprocessing.simulate import run_simulation
 from vampy.automatedPreprocessing.visualize import visualize_model
 
 from fsipy.automatedPreprocessing.preprocessing_common import generate_mesh, distance_to_spheres_solid_thickness, \
-    dist_sphere_spheres, convert_vtu_mesh_to_xdmf
+    dist_sphere_spheres, convert_xml_mesh_to_hdf5, convert_vtu_mesh_to_xdmf
 
 
 def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_factor, smoothing_iterations,
@@ -28,7 +28,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
                        coarsening_factor, inlet_flow_extension_length, outlet_flow_extension_length,
                        number_of_sublayers_fluid, number_of_sublayers_solid, edge_length,
                        region_points, compress_mesh, add_boundary_layer, scale_factor, resampling_step,
-                       meshing_parameters, remove_all, solid_thickness, solid_thickness_parameters):
+                       meshing_parameters, remove_all, solid_thickness, solid_thickness_parameters, mesh_format):
     """
     Automatically generate mesh of surface model in .vtu and .xml format, including prescribed
     flow rates at inlet and outlet based on flow network model.
@@ -62,6 +62,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         remove_all (bool): Remove mesh and all pre-processing files
         solid_thickness (str): Constant or variable mesh thickness
         solid_thickness_parameters (list): Specify parameters for solid thickness
+        mesh_format (str): Specify the format for the generated mesh
     """
     # Get paths
     case_name = input_model.rsplit(path.sep, 1)[-1].rsplit('.')[0]
@@ -425,14 +426,25 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
                                                    solid_thickness,
                                                    solid_thickness_parameters)
 
-        # Write mesh in VTU format
-        write_polydata(remeshed_surface, file_name_surface_name)
-        write_polydata(mesh, file_name_vtu_mesh)
+        if mesh_format in ("xml", "hdf5"):
+            write_mesh(compress_mesh, file_name_surface_name, file_name_vtu_mesh, file_name_xml_mesh,
+                       mesh, remeshed_surface)
+
+            # Add .gz to XML mesh file if compressed
+            if compress_mesh:
+                file_name_xml_mesh = file_name_xml_mesh + ".gz"
+        else:
+            # Write mesh in VTU format
+            write_polydata(remeshed_surface, file_name_surface_name)
+            write_polydata(mesh, file_name_vtu_mesh)
     else:
         mesh = read_polydata(file_name_vtu_mesh)
 
-    # Convert VTU mesh to XDMF
-    convert_vtu_mesh_to_xdmf(file_name_vtu_mesh, file_name_xdmf_mesh)
+    if mesh_format == "hdf5":
+        print("--- Converting XML mesh to HDF5\n")
+        convert_xml_mesh_to_hdf5(file_name_xml_mesh)
+    elif mesh_format == "xdmf":
+        convert_vtu_mesh_to_xdmf(file_name_vtu_mesh, file_name_xdmf_mesh)
 
     network, probe_points = setup_model_network(centerlines, file_name_probe_points, region_center, verbose_print)
 
@@ -573,7 +585,7 @@ def read_command_line(input_path=None):
     parser.add_argument('-f', '--add-flowextensions',
                         default=True,
                         type=str2bool,
-                        help="Add flow extensions to to the model.")
+                        help="Add flow extensions to the model.")
 
     parser.add_argument('-fli', '--inlet-flowextension',
                         default=5,
@@ -653,6 +665,12 @@ def read_command_line(input_path=None):
                              "four floats for the distancetosphere scaling function: 'offset', 'scale', 'min' " +
                              "and 'max'. For example --solid-thickness-parameters 0 0.1 0.25 0.3")
 
+    parser.add_argument('-mf', '--mesh-format',
+                        type=str,
+                        choices=["xml", "hdf5", "xdmf"],
+                        default="hdf5",
+                        help="Specify the format for the generated mesh. Available options: 'xml', 'hdf5', 'xdmf'.")
+
     # Parse path to get default values
     if required:
         args = parser.parse_args()
@@ -691,7 +709,8 @@ def read_command_line(input_path=None):
                 outlet_flow_extension_length=args.outlet_flowextension, add_boundary_layer=args.add_boundary_layer,
                 scale_factor=args.scale_factor, resampling_step=args.resampling_step,
                 meshing_parameters=args.meshing_parameters, remove_all=args.remove_all,
-                solid_thickness=args.solid_thickness, solid_thickness_parameters=args.solid_thickness_parameters)
+                solid_thickness=args.solid_thickness, solid_thickness_parameters=args.solid_thickness_parameters,
+                mesh_format=args.mesh_format)
 
 
 def main_meshing():

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -14,13 +14,13 @@ from morphman import get_uncapped_surface, write_polydata, get_parameters, vtk_c
 from vampy.automatedPreprocessing import ToolRepairSTL
 from vampy.automatedPreprocessing.preprocessing_common import read_polydata, get_centers_for_meshing, \
     dist_sphere_diam, dist_sphere_curvature, dist_sphere_constant, get_regions_to_refine, add_flow_extension, \
-    write_mesh, mesh_alternative, find_boundaries, compute_flow_rate, setup_model_network, \
+    mesh_alternative, find_boundaries, compute_flow_rate, setup_model_network, \
     radiusArrayName, scale_surface, get_furtest_surface_point, check_if_closed_surface
 from vampy.automatedPreprocessing.simulate import run_simulation
 from vampy.automatedPreprocessing.visualize import visualize_model
 
 from fsipy.automatedPreprocessing.preprocessing_common import generate_mesh, distance_to_spheres_solid_thickness, \
-    dist_sphere_spheres, convert_xml_mesh_to_hdf5
+    dist_sphere_spheres, convert_xml_mesh_to_hdf5, convert_vtu_mesh_to_xdmf
 
 
 def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_factor, smoothing_iterations,
@@ -89,6 +89,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
     file_name_surface_name = base_path + "_remeshed_surface.vtp"
     file_name_xml_mesh = base_path + ".xml"
     file_name_vtu_mesh = base_path + ".vtu"
+    file_name_xdmf_mesh = base_path + ".xdmf"
     region_centerlines = None
 
     if remove_all:
@@ -100,7 +101,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
             file_name_probe_points,
             file_name_voronoi, file_name_voronoi_smooth, file_name_voronoi_surface, file_name_surface_smooth,
             file_name_model_flow_ext, file_name_clipped_model, file_name_flow_centerlines, file_name_surface_name,
-            file_name_xml_mesh, file_name_vtu_mesh,
+            file_name_xml_mesh, file_name_vtu_mesh, file_name_xdmf_mesh,
         ]
         for file in files_to_remove:
             if path.exists(file):
@@ -424,17 +425,14 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
                                                    solid_thickness,
                                                    solid_thickness_parameters)
 
-        write_mesh(compress_mesh, file_name_surface_name, file_name_vtu_mesh, file_name_xml_mesh,
-                   mesh, remeshed_surface)
-
-        # Add .gz to XML mesh file if compressed
-        if compress_mesh:
-            file_name_xml_mesh = file_name_xml_mesh + ".gz"
+        # Write mesh in VTU format
+        write_polydata(remeshed_surface, file_name_surface_name)
+        write_polydata(mesh, file_name_vtu_mesh)
     else:
         mesh = read_polydata(file_name_vtu_mesh)
 
-    print("--- Converting XML mesh to HDF5\n")
-    convert_xml_mesh_to_hdf5(file_name_xml_mesh)
+    # Convert VTU mesh to XDMF
+    convert_vtu_mesh_to_xdmf(file_name_vtu_mesh, file_name_xdmf_mesh)
 
     network, probe_points = setup_model_network(centerlines, file_name_probe_points, region_center, verbose_print)
 

--- a/src/fsipy/automatedPreprocessing/preprocessing_common.py
+++ b/src/fsipy/automatedPreprocessing/preprocessing_common.py
@@ -4,6 +4,7 @@ from morphman import vmtkscripts, write_polydata
 from vtk import vtkPolyData
 from dolfin import Mesh, MeshFunction, File, HDF5File
 from pathlib import Path
+import meshio
 
 
 # Global array names
@@ -203,3 +204,47 @@ def convert_xml_mesh_to_hdf5(file_name_xml_mesh: str, scaling_factor: float = 0.
     hdf.write(mesh, "/mesh")
     hdf.write(boundaries, "/boundaries")
     hdf.write(domains, "/domains")
+
+
+def convert_vtu_mesh_to_xdmf(file_name_vtu_mesh: str, file_name_xdmf_mesh: str) -> None:
+    """
+    Convert a VTU mesh to XDMF format using meshio.
+
+    Args:
+        file_name_vtu_mesh (str): Path to the input VTU mesh file.
+        file_name_xdmf_mesh (str): Path to the output XDMF file.
+    """
+    print("--- Converting VTU mesh to XDMF")
+
+    # Load the VTU mesh
+    vtu_mesh = meshio.read(file_name_vtu_mesh)
+
+    # Extract cell data
+    tetra_data = vtu_mesh.cell_data_dict.get("CellEntityIds", {}).get("tetra", None)
+    triangle_data = vtu_mesh.cell_data_dict.get("CellEntityIds", {}).get("triangle", None)
+
+    # Extract cell types and data
+    tetra_cells = None
+    triangle_cells = None
+    for cell in vtu_mesh.cells:
+        if cell.type == "tetra":
+            tetra_cells = cell.data
+        elif cell.type == "triangle":
+            triangle_cells = cell.data
+
+    # Create mesh objects
+    tetra_mesh = meshio.Mesh(points=vtu_mesh.points, cells={"tetra": tetra_cells},
+                             cell_data={"CellEntityIds": [tetra_data]})
+    triangle_mesh = meshio.Mesh(points=vtu_mesh.points, cells=[("triangle", triangle_cells)],
+                                cell_data={"CellEntityIds": [triangle_data]})
+
+    # Define Path objects
+    tetra_xdmf_path = Path(file_name_xdmf_mesh)
+    triangle_xdmf_path = tetra_xdmf_path.with_name(tetra_xdmf_path.stem + '_triangle.xdmf')
+
+    # Write the VTU mesh to XDMF format
+    meshio.write(tetra_xdmf_path, tetra_mesh)
+    meshio.write(triangle_xdmf_path, triangle_mesh)
+
+    print(f"Tetra mesh XDMF file written to: {tetra_xdmf_path}")
+    print(f"Triangle mesh XDMF file written to: {triangle_xdmf_path}\n")

--- a/src/fsipy/automatedPreprocessing/preprocessing_common.py
+++ b/src/fsipy/automatedPreprocessing/preprocessing_common.py
@@ -208,7 +208,7 @@ def convert_xml_mesh_to_hdf5(file_name_xml_mesh: str, scaling_factor: float = 0.
 
 def convert_vtu_mesh_to_xdmf(file_name_vtu_mesh: str, file_name_xdmf_mesh: str) -> None:
     """
-    Convert a VTU mesh to XDMF format using meshio.
+    Convert a VTU mesh to XDMF format using meshio. This function is intended to run in serial.
 
     Args:
         file_name_vtu_mesh (str): Path to the input VTU mesh file.

--- a/tests/test_pre_processing.py
+++ b/tests/test_pre_processing.py
@@ -1,6 +1,6 @@
 import vtk
 from pathlib import Path
-from dolfin import Mesh, XDMFFile
+from dolfin import Mesh, HDF5File, XDMFFile
 from vampy.automatedPreprocessing.preprocessing_common import read_polydata
 from fsipy.automatedPreprocessing.automated_preprocessing import read_command_line, \
     run_pre_processing
@@ -13,7 +13,7 @@ def test_mesh_model_with_one_inlet():
     # Define test data paths
     model_path = Path("tests/test_data/tube/tube.stl")
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_xdmf = model_path.with_suffix(".xdmf")
+    mesh_path_hdf5 = model_path.with_suffix(".h5")
 
     # Define expected values
     expected_num_points = 3626
@@ -39,21 +39,21 @@ def test_mesh_model_with_one_inlet():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
-    assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
+    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
 
     # Check that mesh files are not empty and have expected sizes
     mesh_vtu = read_polydata(str(mesh_path_vtu))
-    mesh_xdmf = Mesh()
+    mesh_hdf5 = Mesh()
     try:
-        with XDMFFile(str(mesh_path_xdmf)) as xdmf_file:
-            xdmf_file.read(mesh_xdmf)
+        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
+        hdf5_file.read(mesh_hdf5, "/mesh", False)
     except Exception as e:
-        print(f"Error reading XDMF mesh: {e}")
+        print(f"Error reading HDF5 mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
         f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points}"
-    assert mesh_xdmf.num_cells() == expected_num_cells, \
-        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells}"
+    assert mesh_hdf5.num_cells() == expected_num_cells, \
+        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells}"
 
 
 def test_mesh_model_with_one_inlet_and_one_outlet():
@@ -63,7 +63,7 @@ def test_mesh_model_with_one_inlet_and_one_outlet():
     # Define test data paths
     model_path = Path("tests/test_data/cylinder/cylinder.vtp")
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_xdmf = model_path.with_suffix(".xdmf")
+    mesh_path_hdf5 = model_path.with_suffix(".h5")
 
     # Define expected values
     expected_num_points = 2153
@@ -89,21 +89,21 @@ def test_mesh_model_with_one_inlet_and_one_outlet():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
-    assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
+    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
 
     # Check that mesh files are not empty and have expected sizes
     mesh_vtu = read_polydata(str(mesh_path_vtu))
-    mesh_xdmf = Mesh()
+    mesh_hdf5 = Mesh()
     try:
-        with XDMFFile(str(mesh_path_xdmf)) as xdmf_file:
-            xdmf_file.read(mesh_xdmf)
+        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
+        hdf5_file.read(mesh_hdf5, "/mesh", False)
     except Exception as e:
-        print(f"Error reading XDMF mesh: {e}")
+        print(f"Error reading HDF5 mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
         f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points}"
-    assert mesh_xdmf.num_cells() == expected_num_cells, \
-        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells}"
+    assert mesh_hdf5.num_cells() == expected_num_cells, \
+        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells}"
 
 
 def test_mesh_model_with_one_inlet_and_two_outlets():
@@ -113,7 +113,7 @@ def test_mesh_model_with_one_inlet_and_two_outlets():
     # Define test data paths
     model_path = Path("tests/test_data/artery/artery.stl")
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_xdmf = model_path.with_suffix(".xdmf")
+    mesh_path_hdf5 = model_path.with_suffix(".h5")
 
     # Define expected values
     expected_num_points = 5860
@@ -139,21 +139,21 @@ def test_mesh_model_with_one_inlet_and_two_outlets():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
-    assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
+    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
 
     # Check that mesh files are not empty and have expected sizes
     mesh_vtu = read_polydata(str(mesh_path_vtu))
-    mesh_xdmf = Mesh()
+    mesh_hdf5 = Mesh()
     try:
-        with XDMFFile(str(mesh_path_xdmf)) as xdmf_file:
-            xdmf_file.read(mesh_xdmf)
+        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
+        hdf5_file.read(mesh_hdf5, "/mesh", False)
     except Exception as e:
-        print(f"Error reading XDMF mesh: {e}")
+        print(f"Error reading HDF5 mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
         f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points}"
-    assert mesh_xdmf.num_cells() == expected_num_cells, \
-        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells}"
+    assert mesh_hdf5.num_cells() == expected_num_cells, \
+        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells}"
 
 
 def test_mesh_model_with_variable_mesh_density():
@@ -167,7 +167,7 @@ def test_mesh_model_with_variable_mesh_density():
     copied_sphere_file_path = sphere_file_path.with_name(model_path.stem + "_distance_to_sphere_spheres.vtp")
 
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_xdmf = model_path.with_suffix(".xdmf")
+    mesh_path_hdf5 = model_path.with_suffix(".h5")
 
     # Make copies of the original model and sphere files using pathlib
     model_path.write_text(original_model_path.read_text())
@@ -197,21 +197,21 @@ def test_mesh_model_with_variable_mesh_density():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
-    assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
+    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
 
     # Check that mesh files are not empty and have expected sizes
     mesh_vtu = read_polydata(str(mesh_path_vtu))
-    mesh_xdmf = Mesh()
+    mesh_hdf5 = Mesh()
     try:
-        with XDMFFile(str(mesh_path_xdmf)) as xdmf_file:
-            xdmf_file.read(mesh_xdmf)
+        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
+        hdf5_file.read(mesh_hdf5, "/mesh", False)
     except Exception as e:
-        print(f"Error reading XDMF mesh: {e}")
+        print(f"Error reading HDF5 mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
         f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points} points"
-    assert mesh_xdmf.num_cells() == expected_num_cells, \
-        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells} cells"
+    assert mesh_hdf5.num_cells() == expected_num_cells, \
+        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells} cells"
 
 
 def compute_cylinder_diameter_at_cut(mesh, point_coords, plane_normal):
@@ -252,7 +252,7 @@ def test_mesh_model_with_variable_solid_thickness():
     copied_sphere_file_path = sphere_file_path.with_name(model_path.stem + "_distance_to_sphere_solid_thickness.vtp")
 
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_xdmf = model_path.with_suffix(".xdmf")
+    mesh_path_hdf5 = model_path.with_suffix(".h5")
 
     # Make copies of the original model and sphere files using pathlib
     model_path.write_text(original_model_path.read_text())
@@ -286,6 +286,70 @@ def test_mesh_model_with_variable_solid_thickness():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
+    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
+
+    # Check that mesh files are not empty and have expected sizes
+    mesh_vtu = read_polydata(str(mesh_path_vtu))
+    mesh_hdf5 = Mesh()
+    try:
+        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
+        hdf5_file.read(mesh_hdf5, "/mesh", False)
+    except Exception as e:
+        print(f"Error reading HDF5 mesh: {e}")
+
+    assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
+        f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points} points"
+    assert mesh_hdf5.num_cells() == expected_num_cells, \
+        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells} cells"
+
+    # Compute diameter at inlet and outlet
+    diameter_at_inlet = compute_cylinder_diameter_at_cut(mesh_vtu, [0, -3.1, 0], [0, 1, 0])
+    diameter_at_outlet = compute_cylinder_diameter_at_cut(mesh_vtu, [0, 3.1, 0], [0, 1, 0])
+
+    assert diameter_at_inlet == expected_diameter_at_inlet, \
+        f"VTU mesh has diameter {diameter_at_inlet} at inlet, expected {expected_diameter_at_inlet}"
+    assert diameter_at_outlet == expected_diameter_at_outlet, \
+        f"VTU mesh has diameter {diameter_at_outlet} at outlet, expected {expected_diameter_at_outlet}"
+
+
+def test_xdmf_mesh_format():
+    """
+    Test meshing procedure with generated mesh in XDMF format.
+    """
+    # Define test data paths
+    original_model_path = Path("tests/test_data/cylinder/cylinder.vtp")
+    model_path = original_model_path.with_name(original_model_path.stem + "_xdmf_mesh_format.vtp")
+    mesh_path_vtu = model_path.with_suffix(".vtu")
+    mesh_path_xdmf = model_path.with_suffix(".xdmf")
+
+    # Make copies of the original model
+    model_path.write_text(original_model_path.read_text())
+
+    # Define expected values
+    expected_num_points = 2153
+    expected_num_cells = 11459
+
+    # Get default input parameters
+    common_input = read_command_line(str(model_path))
+    common_input.update(
+        dict(
+            meshing_method="diameter",
+            smoothing_method="no_smooth",
+            refine_region=False,
+            coarsening_factor=1.3,
+            visualize=False,
+            compress_mesh=False,
+            outlet_flow_extension_length=1,
+            inlet_flow_extension_length=1,
+            mesh_format="xdmf",
+        )
+    )
+
+    # Run pre processing
+    run_pre_processing(**common_input)
+
+    # Check that mesh files are created
+    assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
     assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
 
     # Check that mesh files are not empty and have expected sizes
@@ -298,18 +362,9 @@ def test_mesh_model_with_variable_solid_thickness():
         print(f"Error reading XDMF mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
-        f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points} points"
+        f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points}"
     assert mesh_xdmf.num_cells() == expected_num_cells, \
-        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells} cells"
-
-    # Compute diameter at inlet and outlet
-    diameter_at_inlet = compute_cylinder_diameter_at_cut(mesh_vtu, [0, -3.1, 0], [0, 1, 0])
-    diameter_at_outlet = compute_cylinder_diameter_at_cut(mesh_vtu, [0, 3.1, 0], [0, 1, 0])
-
-    assert diameter_at_inlet == expected_diameter_at_inlet, \
-        f"VTU mesh has diameter {diameter_at_inlet} at inlet, expected {expected_diameter_at_inlet}"
-    assert diameter_at_outlet == expected_diameter_at_outlet, \
-        f"VTU mesh has diameter {diameter_at_outlet} at outlet, expected {expected_diameter_at_outlet}"
+        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells}"
 
 
 if __name__ == "__main__":
@@ -318,3 +373,4 @@ if __name__ == "__main__":
     test_mesh_model_with_one_inlet_and_two_outlets()
     test_mesh_model_with_variable_mesh_density()
     test_mesh_model_with_variable_solid_thickness()
+    test_xdmf_mesh_format()

--- a/tests/test_pre_processing.py
+++ b/tests/test_pre_processing.py
@@ -1,6 +1,6 @@
 import vtk
 from pathlib import Path
-from dolfin import Mesh, HDF5File
+from dolfin import Mesh, XDMFFile
 from vampy.automatedPreprocessing.preprocessing_common import read_polydata
 from fsipy.automatedPreprocessing.automated_preprocessing import read_command_line, \
     run_pre_processing
@@ -13,7 +13,7 @@ def test_mesh_model_with_one_inlet():
     # Define test data paths
     model_path = Path("tests/test_data/tube/tube.stl")
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_hdf5 = model_path.with_suffix(".h5")
+    mesh_path_xdmf = model_path.with_suffix(".xdmf")
 
     # Define expected values
     expected_num_points = 3626
@@ -39,21 +39,21 @@ def test_mesh_model_with_one_inlet():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
-    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
+    assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
 
     # Check that mesh files are not empty and have expected sizes
     mesh_vtu = read_polydata(str(mesh_path_vtu))
-    mesh_hdf5 = Mesh()
+    mesh_xdmf = Mesh()
     try:
-        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
-        hdf5_file.read(mesh_hdf5, "/mesh", False)
+        with XDMFFile(str(mesh_path_xdmf)) as xdmf_file:
+            xdmf_file.read(mesh_xdmf)
     except Exception as e:
-        print(f"Error reading HDF5 mesh: {e}")
+        print(f"Error reading XDMF mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
         f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points}"
-    assert mesh_hdf5.num_cells() == expected_num_cells, \
-        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells}"
+    assert mesh_xdmf.num_cells() == expected_num_cells, \
+        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells}"
 
 
 def test_mesh_model_with_one_inlet_and_one_outlet():
@@ -63,7 +63,7 @@ def test_mesh_model_with_one_inlet_and_one_outlet():
     # Define test data paths
     model_path = Path("tests/test_data/cylinder/cylinder.vtp")
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_hdf5 = model_path.with_suffix(".h5")
+    mesh_path_xdmf = model_path.with_suffix(".xdmf")
 
     # Define expected values
     expected_num_points = 2153
@@ -89,21 +89,21 @@ def test_mesh_model_with_one_inlet_and_one_outlet():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
-    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
+    assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
 
     # Check that mesh files are not empty and have expected sizes
     mesh_vtu = read_polydata(str(mesh_path_vtu))
-    mesh_hdf5 = Mesh()
+    mesh_xdmf = Mesh()
     try:
-        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
-        hdf5_file.read(mesh_hdf5, "/mesh", False)
+        with XDMFFile(str(mesh_path_xdmf)) as xdmf_file:
+            xdmf_file.read(mesh_xdmf)
     except Exception as e:
-        print(f"Error reading HDF5 mesh: {e}")
+        print(f"Error reading XDMF mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
         f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points}"
-    assert mesh_hdf5.num_cells() == expected_num_cells, \
-        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells}"
+    assert mesh_xdmf.num_cells() == expected_num_cells, \
+        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells}"
 
 
 def test_mesh_model_with_one_inlet_and_two_outlets():
@@ -113,7 +113,7 @@ def test_mesh_model_with_one_inlet_and_two_outlets():
     # Define test data paths
     model_path = Path("tests/test_data/artery/artery.stl")
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_hdf5 = model_path.with_suffix(".h5")
+    mesh_path_xdmf = model_path.with_suffix(".xdmf")
 
     # Define expected values
     expected_num_points = 5860
@@ -139,21 +139,21 @@ def test_mesh_model_with_one_inlet_and_two_outlets():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
-    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
+    assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
 
     # Check that mesh files are not empty and have expected sizes
     mesh_vtu = read_polydata(str(mesh_path_vtu))
-    mesh_hdf5 = Mesh()
+    mesh_xdmf = Mesh()
     try:
-        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
-        hdf5_file.read(mesh_hdf5, "/mesh", False)
+        with XDMFFile(str(mesh_path_xdmf)) as xdmf_file:
+            xdmf_file.read(mesh_xdmf)
     except Exception as e:
-        print(f"Error reading HDF5 mesh: {e}")
+        print(f"Error reading XDMF mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
         f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points}"
-    assert mesh_hdf5.num_cells() == expected_num_cells, \
-        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells}"
+    assert mesh_xdmf.num_cells() == expected_num_cells, \
+        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells}"
 
 
 def test_mesh_model_with_variable_mesh_density():
@@ -167,7 +167,7 @@ def test_mesh_model_with_variable_mesh_density():
     copied_sphere_file_path = sphere_file_path.with_name(model_path.stem + "_distance_to_sphere_spheres.vtp")
 
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_hdf5 = model_path.with_suffix(".h5")
+    mesh_path_xdmf = model_path.with_suffix(".xdmf")
 
     # Make copies of the original model and sphere files using pathlib
     model_path.write_text(original_model_path.read_text())
@@ -197,21 +197,21 @@ def test_mesh_model_with_variable_mesh_density():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
-    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
+    assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
 
     # Check that mesh files are not empty and have expected sizes
     mesh_vtu = read_polydata(str(mesh_path_vtu))
-    mesh_hdf5 = Mesh()
+    mesh_xdmf = Mesh()
     try:
-        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
-        hdf5_file.read(mesh_hdf5, "/mesh", False)
+        with XDMFFile(str(mesh_path_xdmf)) as xdmf_file:
+            xdmf_file.read(mesh_xdmf)
     except Exception as e:
-        print(f"Error reading HDF5 mesh: {e}")
+        print(f"Error reading XDMF mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
         f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points} points"
-    assert mesh_hdf5.num_cells() == expected_num_cells, \
-        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells} cells"
+    assert mesh_xdmf.num_cells() == expected_num_cells, \
+        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells} cells"
 
 
 def compute_cylinder_diameter_at_cut(mesh, point_coords, plane_normal):
@@ -252,7 +252,7 @@ def test_mesh_model_with_variable_solid_thickness():
     copied_sphere_file_path = sphere_file_path.with_name(model_path.stem + "_distance_to_sphere_solid_thickness.vtp")
 
     mesh_path_vtu = model_path.with_suffix(".vtu")
-    mesh_path_hdf5 = model_path.with_suffix(".h5")
+    mesh_path_xdmf = model_path.with_suffix(".xdmf")
 
     # Make copies of the original model and sphere files using pathlib
     model_path.write_text(original_model_path.read_text())
@@ -286,21 +286,21 @@ def test_mesh_model_with_variable_solid_thickness():
 
     # Check that mesh files are created
     assert mesh_path_vtu.is_file(), f"VTU mesh file not found at {mesh_path_vtu}"
-    assert mesh_path_hdf5.is_file(), f"HDF5 mesh file not found at {mesh_path_hdf5}"
+    assert mesh_path_xdmf.is_file(), f"XDMF mesh file not found at {mesh_path_xdmf}"
 
     # Check that mesh files are not empty and have expected sizes
     mesh_vtu = read_polydata(str(mesh_path_vtu))
-    mesh_hdf5 = Mesh()
+    mesh_xdmf = Mesh()
     try:
-        hdf5_file = HDF5File(mesh_hdf5.mpi_comm(), str(mesh_path_hdf5), "r")
-        hdf5_file.read(mesh_hdf5, "/mesh", False)
+        with XDMFFile(str(mesh_path_xdmf)) as xdmf_file:
+            xdmf_file.read(mesh_xdmf)
     except Exception as e:
-        print(f"Error reading HDF5 mesh: {e}")
+        print(f"Error reading XDMF mesh: {e}")
 
     assert mesh_vtu.GetNumberOfPoints() == expected_num_points, \
         f"VTU mesh has {mesh_vtu.GetNumberOfPoints()} points, expected {expected_num_points} points"
-    assert mesh_hdf5.num_cells() == expected_num_cells, \
-        f"HDF5 mesh has {mesh_hdf5.num_cells()} cells, expected {expected_num_cells} cells"
+    assert mesh_xdmf.num_cells() == expected_num_cells, \
+        f"XDMF mesh has {mesh_xdmf.num_cells()} cells, expected {expected_num_cells} cells"
 
     # Compute diameter at inlet and outlet
     diameter_at_inlet = compute_cylinder_diameter_at_cut(mesh_vtu, [0, -3.1, 0], [0, 1, 0])


### PR DESCRIPTION
In this pull request a new function `convert_vtu_mesh_to_xdmf` has been added, enabling the conversion of VTU mesh data to the XDMF format using the `meshio` library. Currently, the mesh is converted from VTU to XML and from XML to HDF5. With the change in this PR, the mesh is converted directly from VTU to XDMF. The resulting XDMF mesh can be used in the same way as in [Stenosis_2D.py](https://github.com/KVSlab/turtleFSI/blob/34925bed03008e463ce6ddc82b875287fc866177/turtleFSI/problems/Stenosis_2D.py#L69-L91) in turtleFSI. One thing that is good about using XDMF is that the mesh can easily be viewed in ParaView. Do we want to keep using HDF5 or should we switch to XDMF? Please let me know your thoughts.