### PR TITLE
Include mesh IDs in parameter file

### DIFF
--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -28,8 +28,8 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
                        coarsening_factor, inlet_flow_extension_length, outlet_flow_extension_length,
                        number_of_sublayers_fluid, number_of_sublayers_solid, edge_length,
                        region_points, compress_mesh, scale_factor, resampling_step, meshing_parameters,
-                       remove_all, solid_thickness, solid_thickness_parameters, mesh_format,
-                       flow_rate_factor):
+                       remove_all, solid_thickness, solid_thickness_parameters, mesh_format, flow_rate_factor,
+                       solid_side_wall_id, interface_fsi_id, interface_outer_id, volume_id_fluid, volume_id_solid):
     """
     Automatically generate mesh of surface model in .vtu and .xml format, including prescribed
     flow rates at inlet and outlet based on flow network model.
@@ -64,6 +64,11 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         solid_thickness_parameters (list): Specify parameters for solid thickness
         mesh_format (str): Specify the format for the generated mesh
         flow_rate_factor (float): Flow rate factor
+        solid_side_wall_id (int): ID for solid side wall
+        interface_fsi_id (int): ID for the FSI interface
+        interface_outer_id (int): ID for the outer interface
+        volume_id_fluid (int): ID for the fluid volume
+        volume_id_solid (int): ID for the solid volume
     """
     # Get paths
     case_name = input_model.rsplit(path.sep, 1)[-1].rsplit('.')[0]
@@ -439,6 +444,14 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
             # Write mesh in VTU format
             write_polydata(remeshed_surface, file_name_surface_name)
             write_polydata(mesh, file_name_vtu_mesh)
+
+        # Write the mesh ID's to parameter file
+        parameters["solid_side_wall_id"] = solid_side_wall_id
+        parameters["interface_fsi_id"] = interface_fsi_id
+        parameters["interface_outer_id"] = interface_outer_id
+        parameters["volume_id_fluid"] = volume_id_fluid
+        parameters["volume_id_solid"] = volume_id_solid
+        write_parameters(parameters, base_path)
     else:
         mesh = read_polydata(file_name_vtu_mesh)
 
@@ -682,6 +695,12 @@ def read_command_line(input_path=None):
                         type=float,
                         help="Flow rate factor.")
 
+    parser.add_argument("--solid-side-wall-id", type=int, default=11, help="ID for solid side wall")
+    parser.add_argument("--interface-fsi-id", type=int, default=22, help="ID for the FSI interface")
+    parser.add_argument("--interface-outer-id", type=int, default=33, help="ID for the outer interface")
+    parser.add_argument("--volume-id-fluid", type=int, default=0, help="ID for the fluid volume")
+    parser.add_argument("--volume-id-solid", type=int, default=1, help="ID for the solid volume")
+
     # Parse path to get default values
     if required:
         args = parser.parse_args()
@@ -721,7 +740,10 @@ def read_command_line(input_path=None):
                 scale_factor=args.scale_factor, resampling_step=args.resampling_step,
                 meshing_parameters=args.meshing_parameters, remove_all=args.remove_all,
                 solid_thickness=args.solid_thickness, solid_thickness_parameters=args.solid_thickness_parameters,
-                mesh_format=args.mesh_format, flow_rate_factor=args.flow_rate_factor)
+                mesh_format=args.mesh_format, flow_rate_factor=args.flow_rate_factor,
+                solid_side_wall_id=args.solid_side_wall_id, interface_fsi_id=args.interface_fsi_id,
+                interface_outer_id=args.interface_outer_id, volume_id_fluid=args.volume_id_fluid,
+                volume_id_solid=args.volume_id_solid)
 
 
 def main_meshing():

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -29,7 +29,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
                        number_of_sublayers_fluid, number_of_sublayers_solid, edge_length,
                        region_points, compress_mesh, scale_factor, resampling_step, meshing_parameters,
                        remove_all, solid_thickness, solid_thickness_parameters, mesh_format, flow_rate_factor,
-                       solid_side_wall_id, interface_fsi_id, interface_outer_id, volume_id_fluid, volume_id_solid):
+                       solid_side_wall_id, interface_fsi_id, solid_outer_wall_id, fluid_volume_id, solid_volume_id):
     """
     Automatically generate mesh of surface model in .vtu and .xml format, including prescribed
     flow rates at inlet and outlet based on flow network model.
@@ -66,9 +66,9 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         flow_rate_factor (float): Flow rate factor
         solid_side_wall_id (int): ID for solid side wall
         interface_fsi_id (int): ID for the FSI interface
-        interface_outer_id (int): ID for the outer interface
-        volume_id_fluid (int): ID for the fluid volume
-        volume_id_solid (int): ID for the solid volume
+        solid_outer_wall_id (int): ID for the solid outer wall
+        fluid_volume_id (int): ID for the fluid volume
+        solid_volume_id (int): ID for the solid volume
     """
     # Get paths
     case_name = input_model.rsplit(path.sep, 1)[-1].rsplit('.')[0]
@@ -448,9 +448,9 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         # Write the mesh ID's to parameter file
         parameters["solid_side_wall_id"] = solid_side_wall_id
         parameters["interface_fsi_id"] = interface_fsi_id
-        parameters["interface_outer_id"] = interface_outer_id
-        parameters["volume_id_fluid"] = volume_id_fluid
-        parameters["volume_id_solid"] = volume_id_solid
+        parameters["solid_outer_wall_id"] = solid_outer_wall_id
+        parameters["fluid_volume_id"] = fluid_volume_id
+        parameters["solid_volume_id"] = solid_volume_id
         write_parameters(parameters, base_path)
     else:
         mesh = read_polydata(file_name_vtu_mesh)
@@ -697,9 +697,9 @@ def read_command_line(input_path=None):
 
     parser.add_argument("--solid-side-wall-id", type=int, default=11, help="ID for solid side wall")
     parser.add_argument("--interface-fsi-id", type=int, default=22, help="ID for the FSI interface")
-    parser.add_argument("--interface-outer-id", type=int, default=33, help="ID for the outer interface")
-    parser.add_argument("--volume-id-fluid", type=int, default=0, help="ID for the fluid volume")
-    parser.add_argument("--volume-id-solid", type=int, default=1, help="ID for the solid volume")
+    parser.add_argument("--solid-outer-wall-id", type=int, default=33, help="ID for the solid outer wall")
+    parser.add_argument("--fluid-volume-id", type=int, default=0, help="ID for the fluid volume")
+    parser.add_argument("--solid-volume-id", type=int, default=1, help="ID for the solid volume")
 
     # Parse path to get default values
     if required:
@@ -742,8 +742,8 @@ def read_command_line(input_path=None):
                 solid_thickness=args.solid_thickness, solid_thickness_parameters=args.solid_thickness_parameters,
                 mesh_format=args.mesh_format, flow_rate_factor=args.flow_rate_factor,
                 solid_side_wall_id=args.solid_side_wall_id, interface_fsi_id=args.interface_fsi_id,
-                interface_outer_id=args.interface_outer_id, volume_id_fluid=args.volume_id_fluid,
-                volume_id_solid=args.volume_id_solid)
+                solid_outer_wall_id=args.solid_outer_wall_id, fluid_volume_id=args.fluid_volume_id,
+                solid_volume_id=args.solid_volume_id)
 
 
 def main_meshing():

--- a/src/fsipy/automatedPreprocessing/preprocessing_common.py
+++ b/src/fsipy/automatedPreprocessing/preprocessing_common.py
@@ -103,8 +103,8 @@ def dist_sphere_spheres(surface: vtkPolyData, save_path: str,
 
 def generate_mesh(surface: vtkPolyData, number_of_sublayers_fluid: int, number_of_sublayers_solid: int,
                   solid_thickness: str, solid_thickness_parameters: list,
-                  solid_side_wall_id: int = 11, interface_fsi_id: int = 22, interface_outer_id: int = 33,
-                  volume_id_fluid: int = 0, volume_id_solid: int = 1) -> tuple:
+                  solid_side_wall_id: int = 11, interface_fsi_id: int = 22, solid_outer_wall_id: int = 33,
+                  fluid_volume_id: int = 0, solid_volume_id: int = 1) -> tuple:
     """
     Generates a mesh suitable for FSI from an input surface model.
 
@@ -116,9 +116,9 @@ def generate_mesh(surface: vtkPolyData, number_of_sublayers_fluid: int, number_o
         solid_thickness_parameters (list): List of parameters for solid thickness.
         solid_side_wall_id (int, optional): ID for solid side wall. Default is 11.
         interface_fsi_id (int, optional): ID for the FSI interface. Default is 22.
-        interface_outer_id (int, optional): ID for the outer interface. Default is 33.
-        volume_id_fluid (int, optional): ID for the fluid volume. Default is 0.
-        volume_id_solid (int, optional): ID for the solid volume. Default is 1.
+        solid_outer_wall_id (int, optional): ID for solid outer wall. Default is 33.
+        fluid_volume_id (int, optional): ID for the fluid volume. Default is 0.
+        solid_volume_id (int, optional): ID for the solid volume. Default is 1.
 
     Returns:
         tuple: A tuple containing the generated mesh (vtkUnstructuredGrid) and the remeshed surface (vtkPolyData).
@@ -154,9 +154,9 @@ def generate_mesh(surface: vtkPolyData, number_of_sublayers_fluid: int, number_o
     # IDs
     meshGenerator.SolidSideWallId = solid_side_wall_id
     meshGenerator.InterfaceFsiId = interface_fsi_id
-    meshGenerator.InterfaceOuterId = interface_outer_id
-    meshGenerator.VolumeIdFluid = volume_id_fluid
-    meshGenerator.VolumeIdSolid = volume_id_solid
+    meshGenerator.SolidOuterWallId = solid_outer_wall_id
+    meshGenerator.FluidVolumeId = fluid_volume_id
+    meshGenerator.SolidVolumeId = solid_volume_id
 
     # Generate mesh
     meshGenerator.Execute()

--- a/src/fsipy/automatedPreprocessing/preprocessing_common.py
+++ b/src/fsipy/automatedPreprocessing/preprocessing_common.py
@@ -102,16 +102,23 @@ def dist_sphere_spheres(surface: vtkPolyData, save_path: str,
 
 
 def generate_mesh(surface: vtkPolyData, number_of_sublayers_fluid: int, number_of_sublayers_solid: int,
-                  solid_thickness: str, solid_thickness_parameters: list) -> tuple:
+                  solid_thickness: str, solid_thickness_parameters: list,
+                  solid_side_wall_id: int = 11, interface_fsi_id: int = 22, interface_outer_id: int = 33,
+                  volume_id_fluid: int = 0, volume_id_solid: int = 1) -> tuple:
     """
     Generates a mesh suitable for FSI from an input surface model.
 
     Args:
         surface (vtkPolyData): Surface model to be meshed.
         number_of_sublayers_fluid (int): Number of sublayers for fluid.
-        number_of_sublayers_solud (int): Number of sublayers for solid.
+        number_of_sublayers_solid (int): Number of sublayers for solid.
         solid_thickness (str): Type of solid thickness ('variable' or 'constant').
         solid_thickness_parameters (list): List of parameters for solid thickness.
+        solid_side_wall_id (int, optional): ID for solid side wall. Default is 11.
+        interface_fsi_id (int, optional): ID for the FSI interface. Default is 22.
+        interface_outer_id (int, optional): ID for the outer interface. Default is 33.
+        volume_id_fluid (int, optional): ID for the fluid volume. Default is 0.
+        volume_id_solid (int, optional): ID for the solid volume. Default is 1.
 
     Returns:
         tuple: A tuple containing the generated mesh (vtkUnstructuredGrid) and the remeshed surface (vtkPolyData).
@@ -145,11 +152,11 @@ def generate_mesh(surface: vtkPolyData, number_of_sublayers_fluid: int, number_o
         meshGenerator.SolidThickness = solid_thickness_parameters[0]
 
     # IDs
-    meshGenerator.SolidSideWallId = 11
-    meshGenerator.InterfaceId_fsi = 22
-    meshGenerator.InterfaceId_outer = 33
-    meshGenerator.VolumeId_fluid = 0  # (keep to 0)
-    meshGenerator.VolumeId_solid = 1
+    meshGenerator.SolidSideWallId = solid_side_wall_id
+    meshGenerator.InterfaceFsiId = interface_fsi_id
+    meshGenerator.InterfaceOuterId = interface_outer_id
+    meshGenerator.VolumeIdFluid = volume_id_fluid
+    meshGenerator.VolumeIdSolid = volume_id_solid
 
     # Generate mesh
     meshGenerator.Execute()

--- a/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
+++ b/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
@@ -70,9 +70,9 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
 
         self.SolidSideWallId = 11
         self.InterfaceFsiId = 22
-        self.InterfaceOuterId = 33
-        self.VolumeIdFluid = 0  # (keep to 0)
-        self.VolumeIdSolid = 1
+        self.SolidOuterWallId = 33
+        self.FluidVolumeId = 0  # (keep to 0)
+        self.SolidVolumeId = 1
 
         self.isAVF = False
         self.VeinIdsOffset = 1000
@@ -212,7 +212,7 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             if not self.BoundaryLayerOnCaps:
                 boundaryLayer.SidewallCellEntityId = placeholderCellEntityId
                 boundaryLayer.InnerSurfaceCellEntityId = wallEntityOffset
-                boundaryLayer.VolumeCellEntityId = self.VolumeIdFluid
+                boundaryLayer.VolumeCellEntityId = self.FluidVolumeId
             boundaryLayer.Execute()
 
             self.PrintLog("Generating boundary layer solid")
@@ -236,8 +236,8 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             if not self.BoundaryLayerOnCaps:
                 boundaryLayer2.SidewallCellEntityId = self.SolidSideWallId
                 boundaryLayer2.InnerSurfaceCellEntityId = self.InterfaceFsiId
-                boundaryLayer2.OuterSurfaceCellEntityId = self.InterfaceOuterId
-                boundaryLayer2.VolumeCellEntityId = self.VolumeIdSolid
+                boundaryLayer2.OuterSurfaceCellEntityId = self.SolidOuterWallId
+                boundaryLayer2.VolumeCellEntityId = self.SolidVolumeId
             boundaryLayer2.Execute()
 
             meshToSurface = vmtkscripts.vmtkMeshToSurface()

--- a/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
+++ b/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
@@ -69,10 +69,10 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
         self.SizingFunctionArrayName = 'VolumeSizingFunction'
 
         self.SolidSideWallId = 11
-        self.InterfaceId_fsi = 22
-        self.InterfaceId_outer = 33
-        self.VolumeId_fluid = 0  # (keep to 0)
-        self.VolumeId_solid = 1
+        self.InterfaceFsiId = 22
+        self.InterfaceOuterId = 33
+        self.VolumeIdFluid = 0  # (keep to 0)
+        self.VolumeIdSolid = 1
 
         self.isAVF = False
         self.VeinIdsOffset = 1000
@@ -212,7 +212,7 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             if not self.BoundaryLayerOnCaps:
                 boundaryLayer.SidewallCellEntityId = placeholderCellEntityId
                 boundaryLayer.InnerSurfaceCellEntityId = wallEntityOffset
-                boundaryLayer.VolumeCellEntityId = self.VolumeId_fluid
+                boundaryLayer.VolumeCellEntityId = self.VolumeIdFluid
             boundaryLayer.Execute()
 
             self.PrintLog("Generating boundary layer solid")
@@ -234,10 +234,10 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             boundaryLayer2.Thickness = self.SolidThickness
             boundaryLayer2.ThicknessRatio = 1
             if not self.BoundaryLayerOnCaps:
-                boundaryLayer2.SidewallCellEntityId = self.SolidSideWallId  # placeholderCellEntityId
-                boundaryLayer2.InnerSurfaceCellEntityId = self.InterfaceId_fsi  # wallEntityOffset
-                boundaryLayer2.OuterSurfaceCellEntityId = self.InterfaceId_outer  # wallEntityOffset
-                boundaryLayer2.VolumeCellEntityId = self.VolumeId_solid
+                boundaryLayer2.SidewallCellEntityId = self.SolidSideWallId
+                boundaryLayer2.InnerSurfaceCellEntityId = self.InterfaceFsiId
+                boundaryLayer2.OuterSurfaceCellEntityId = self.InterfaceOuterId
+                boundaryLayer2.VolumeCellEntityId = self.VolumeIdSolid
             boundaryLayer2.Execute()
 
             meshToSurface = vmtkscripts.vmtkMeshToSurface()
@@ -336,7 +336,7 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
                 remeshing.TargetEdgeLengthArrayName = self.TargetEdgeLengthArrayName
                 remeshing.TriangleSplitFactor = self.TriangleSplitFactor
                 remeshing.ElementSizeMode = self.ElementSizeMode
-                remeshing.ExcludeEntityIds = [wallEntityOffset]  # [wallEntityOffset, InterfaceId] #[wallEntityOffset]
+                remeshing.ExcludeEntityIds = [wallEntityOffset]
                 remeshing.Execute()
 
                 innerSurface = remeshing.Surface

--- a/src/fsipy/simulations/simulation_common.py
+++ b/src/fsipy/simulations/simulation_common.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, NamedTuple
 from pathlib import Path
 
 import numpy as np
@@ -107,7 +107,37 @@ def print_mesh_summary(mesh: Mesh) -> None:
         print(f"Number of cells per volume: {combined_info['num_cells'] / volume}\n")
 
 
-def load_mesh_info(mesh_path: Union[str, Path]) -> Tuple[List[int], List[int], int, float, List[float], List[float]]:
+class MeshInfo(NamedTuple):
+    """
+    Represents mesh information.
+
+    Attributes:
+        id_in (List[int]): List of inlet IDs.
+        id_out (List[int]): List of outlet IDs.
+        id_wall (int): Computed wall ID.
+        Q_mean (float): Mean flow rate.
+        area_ratio (List[float]): List of area ratios.
+        area_inlet (List[float]): List of inlet areas.
+        solid_side_wall_id (int): ID for solid side wall.
+        interface_fsi_id (int): ID for the FSI interface.
+        interface_outer_id (int): ID for the outer interface.
+        volume_id_fluid (int): ID for the fluid volume.
+        volume_id_solid (int): ID for the solid volume.
+    """
+    id_in: List[int]
+    id_out: List[int]
+    id_wall: int
+    Q_mean: float
+    area_ratio: List[float]
+    area_inlet: List[float]
+    solid_side_wall_id: int
+    interface_fsi_id: int
+    interface_outer_id: int
+    volume_id_fluid: int
+    volume_id_solid: int
+
+
+def load_mesh_info(mesh_path: Union[str, Path]) -> MeshInfo:
     """
     Load and process mesh information from a JSON file.
 
@@ -115,15 +145,7 @@ def load_mesh_info(mesh_path: Union[str, Path]) -> Tuple[List[int], List[int], i
         mesh_path (str or Path): The path to the mesh file.
 
     Returns:
-        Tuple[List[int], List[int], int, float, List[float], List[float]]:
-            A tuple containing:
-            - id_in (List[int]): List of inlet IDs.
-            - id_out (List[int]): List of outlet IDs.
-            - id_wall (int): Computed wall ID.
-            - Q_mean (float): Mean flow rate.
-            - area_ratio (List[float]): List of area ratios.
-            - area_inlet (List[float]): List of inlet areas.
-
+        MeshInfo: A named tuple containing mesh information.
     Raises:
         FileNotFoundError: If the info file is not found.
     """
@@ -143,8 +165,15 @@ def load_mesh_info(mesh_path: Union[str, Path]) -> Tuple[List[int], List[int], i
     Q_mean = info['mean_flow_rate']
     area_ratio = info['area_ratio']
     area_inlet = info['inlet_area']
+    solid_side_wall_id = info["solid_side_wall_id"]
+    interface_fsi_id = info["interface_fsi_id"]
+    interface_outer_id = info["interface_outer_id"]
+    volume_id_fluid = info["volume_id_fluid"]
+    volume_id_solid = info["volume_id_solid"]
 
-    return id_in, id_out, id_wall, Q_mean, area_ratio, area_inlet
+    return MeshInfo(id_in, id_out, id_wall, Q_mean, area_ratio, area_inlet,
+                    solid_side_wall_id, interface_fsi_id, interface_outer_id,
+                    volume_id_fluid, volume_id_solid)
 
 
 def load_probe_points(mesh_path: Union[str, Path]) -> np.ndarray:

--- a/src/fsipy/simulations/simulation_common.py
+++ b/src/fsipy/simulations/simulation_common.py
@@ -132,9 +132,9 @@ class MeshInfo(NamedTuple):
     area_inlet: List[float]
     solid_side_wall_id: int
     interface_fsi_id: int
-    interface_outer_id: int
-    volume_id_fluid: int
-    volume_id_solid: int
+    solid_outer_wall_id: int
+    fluid_volume_id: int
+    solid_volume_id: int
 
 
 def load_mesh_info(mesh_path: Union[str, Path]) -> MeshInfo:
@@ -167,13 +167,12 @@ def load_mesh_info(mesh_path: Union[str, Path]) -> MeshInfo:
     area_inlet = info['inlet_area']
     solid_side_wall_id = info["solid_side_wall_id"]
     interface_fsi_id = info["interface_fsi_id"]
-    interface_outer_id = info["interface_outer_id"]
-    volume_id_fluid = info["volume_id_fluid"]
-    volume_id_solid = info["volume_id_solid"]
+    solid_outer_wall_id = info["solid_outer_wall_id"]
+    fluid_volume_id = info["fluid_volume_id"]
+    solid_volume_id = info["solid_volume_id"]
 
-    return MeshInfo(id_in, id_out, id_wall, Q_mean, area_ratio, area_inlet,
-                    solid_side_wall_id, interface_fsi_id, interface_outer_id,
-                    volume_id_fluid, volume_id_solid)
+    return MeshInfo(id_in, id_out, id_wall, Q_mean, area_ratio, area_inlet, solid_side_wall_id, interface_fsi_id,
+                    solid_outer_wall_id, fluid_volume_id, solid_volume_id)
 
 
 def load_probe_points(mesh_path: Union[str, Path]) -> np.ndarray:

--- a/tests/test_simulation_common.py
+++ b/tests/test_simulation_common.py
@@ -116,23 +116,40 @@ def test_load_mesh_info(temporary_hdf5_file):
     expected_Q_mean = 2.4817264611257612
     expected_area_ratio = [0.4124865453872114, 0.5875134546127886]
     expected_area_inlet = 8.00556922943794
+    expected_solid_side_wall_id = 11
+    expected_interface_fsi_id = 22
+    expected_interface_outer_id = 33
+    expected_volume_id_fluid = 0
+    expected_volume_id_solid = 1
 
     # Test the load_mesh_info function with the temporary JSON info file
-    id_in, id_out, id_wall, Q_mean, area_ratio, area_inlet = load_mesh_info(temporary_hdf5_file)
+    mesh_info = load_mesh_info(temporary_hdf5_file)
 
-    # Print the actual and expected values in assert calls
-    assert id_in == expected_id_in, \
-        f"Actual id_in: {id_in}, Expected id_in: {expected_id_in}"
-    assert id_out == expected_id_out, \
-        f"Actual id_out: {id_out}, Expected id_out: {expected_id_out}"
-    assert id_wall == expected_id_wall, \
-        f"Actual id_wall: {id_wall}, Expected id_wall: {expected_id_wall}"
-    assert Q_mean == expected_Q_mean, \
-        f"Actual Q_mean: {Q_mean}, Expected Q_mean: {expected_Q_mean}"
-    assert area_ratio == expected_area_ratio, \
-        f"Actual area_ratio: {area_ratio}, Expected area_ratio: {expected_area_ratio}"
-    assert area_inlet == expected_area_inlet, \
-        f"Actual area_inlet: {area_inlet}, Expected area_inlet: {expected_area_inlet}"
+    # Assertions using named tuple components
+    assert mesh_info.id_in == expected_id_in, \
+        f"Actual id_in: {mesh_info.id_in}, Expected id_in: {expected_id_in}"
+    assert mesh_info.id_out == expected_id_out, \
+        f"Actual id_out: {mesh_info.id_out}, Expected id_out: {expected_id_out}"
+    assert mesh_info.id_wall == expected_id_wall, \
+        f"Actual id_wall: {mesh_info.id_wall}, Expected id_wall: {expected_id_wall}"
+    assert mesh_info.Q_mean == expected_Q_mean, \
+        f"Actual Q_mean: {mesh_info.Q_mean}, Expected Q_mean: {expected_Q_mean}"
+    assert mesh_info.area_ratio == expected_area_ratio, \
+        f"Actual area_ratio: {mesh_info.area_ratio}, Expected area_ratio: {expected_area_ratio}"
+    assert mesh_info.area_inlet == expected_area_inlet, \
+        f"Actual area_inlet: {mesh_info.area_inlet}, Expected area_inlet: {expected_area_inlet}"
+    assert mesh_info.solid_side_wall_id == expected_solid_side_wall_id, \
+        f"Actual solid_side_wall_id: {mesh_info.solid_side_wall_id}, " \
+        f"Expected solid_side_wall_id: {expected_solid_side_wall_id}"
+    assert mesh_info.interface_fsi_id == expected_interface_fsi_id, \
+        f"Actual interface_fsi_id: {mesh_info.interface_fsi_id}, Expected interface_fsi_id: {expected_interface_fsi_id}"
+    assert mesh_info.interface_outer_id == expected_interface_outer_id, \
+        f"Actual interface_outer_id: {mesh_info.interface_outer_id}, " \
+        f"Expected interface_outer_id: {expected_interface_outer_id}"
+    assert mesh_info.volume_id_fluid == expected_volume_id_fluid, \
+        f"Actual volume_id_fluid: {mesh_info.volume_id_fluid}, Expected volume_id_fluid: {expected_volume_id_fluid}"
+    assert mesh_info.volume_id_solid == expected_volume_id_solid, \
+        f"Actual volume_id_solid: {mesh_info.volume_id_solid}, Expected volume_id_solid: {expected_volume_id_solid}"
 
 
 def test_print_mesh_summary(temporary_hdf5_file):

--- a/tests/test_simulation_common.py
+++ b/tests/test_simulation_common.py
@@ -118,9 +118,9 @@ def test_load_mesh_info(temporary_hdf5_file):
     expected_area_inlet = 8.00556922943794
     expected_solid_side_wall_id = 11
     expected_interface_fsi_id = 22
-    expected_interface_outer_id = 33
-    expected_volume_id_fluid = 0
-    expected_volume_id_solid = 1
+    expected_solid_outer_wall_id = 33
+    expected_fluid_volume_id = 0
+    expected_solid_volume_id = 1
 
     # Test the load_mesh_info function with the temporary JSON info file
     mesh_info = load_mesh_info(temporary_hdf5_file)
@@ -143,13 +143,13 @@ def test_load_mesh_info(temporary_hdf5_file):
         f"Expected solid_side_wall_id: {expected_solid_side_wall_id}"
     assert mesh_info.interface_fsi_id == expected_interface_fsi_id, \
         f"Actual interface_fsi_id: {mesh_info.interface_fsi_id}, Expected interface_fsi_id: {expected_interface_fsi_id}"
-    assert mesh_info.interface_outer_id == expected_interface_outer_id, \
-        f"Actual interface_outer_id: {mesh_info.interface_outer_id}, " \
-        f"Expected interface_outer_id: {expected_interface_outer_id}"
-    assert mesh_info.volume_id_fluid == expected_volume_id_fluid, \
-        f"Actual volume_id_fluid: {mesh_info.volume_id_fluid}, Expected volume_id_fluid: {expected_volume_id_fluid}"
-    assert mesh_info.volume_id_solid == expected_volume_id_solid, \
-        f"Actual volume_id_solid: {mesh_info.volume_id_solid}, Expected volume_id_solid: {expected_volume_id_solid}"
+    assert mesh_info.solid_outer_wall_id == expected_solid_outer_wall_id, \
+        f"Actual solid_outer_wall_id: {mesh_info.solid_outer_wall_id}, " \
+        f"Expected solid_outer_wall_id: {expected_solid_outer_wall_id}"
+    assert mesh_info.fluid_volume_id == expected_fluid_volume_id, \
+        f"Actual fluid_volume_id: {mesh_info.fluid_volume_id}, Expected fluid_volume_id: {expected_fluid_volume_id}"
+    assert mesh_info.solid_volume_id == expected_solid_volume_id, \
+        f"Actual solid_volume_id: {mesh_info.solid_volume_id}, Expected solid_volume_id: {expected_solid_volume_id}"
 
 
 def test_print_mesh_summary(temporary_hdf5_file):


### PR DESCRIPTION
This change adds new command line arguments to `fsipy-mesh`, specifically `--solid-side-wall-id`, `--interface-fsi-id`, `--interface-outer-id`, `--volume-id-fluid`, and `--volume-id-solid`. It also adds the functionality to write these ID values to the parameters file (`_info.json`). The `generate_mesh` function in `preprocessing_common.py` now also accepts these ID values as arguments. The change also includes modifications to the `load_mesh_info` function in `simulation_common.py` to return a named tuple `MeshInfo` containing all relevant mesh information, including the new ID values. The test functions have also been updated to reflect these changes.