### PR TITLE
Restructure package imports to avoid import of unnecessary submodules

### DIFF
--- a/src/fsipy/__init__.py
+++ b/src/fsipy/__init__.py
@@ -1,17 +1,5 @@
-"""Top-level package for VaMPy."""
+"""Top-level package for fsipy."""
 from importlib.metadata import metadata
-
-# Imports from post-processing
-#from .automatedPostprocessing import compute_flow_and_simulation_metrics
-#from .automatedPostprocessing import postprocessing_common
-# Imports from pre-processing
-from .automatedPreprocessing import automated_preprocessing
-from .automatedPreprocessing import preprocessing_common
-from .automatedPreprocessing import predeform_mesh
-# Imports from simulation scripts
-#from .simulation import Aneurysm
-#from .simulation import AVF
-from .simulations import simulation_common
 
 
 meta = metadata("fsipy")
@@ -20,15 +8,3 @@ __author__ = meta["Author"]
 __license__ = meta["License"]
 __email__ = meta["Author-email"]
 __program_name__ = meta["Name"]
-
-__all__ = [
-#    "compute_flow_and_simulation_metrics",
-#    "postprocessing_common",
-    "automated_preprocessing",
-    "preprocessing_common",
-    "predeform_mesh",
-#    "Aneurysm",
-#    "AVF",
-#    "Stenosis",
-    "simulation_common",
-]

--- a/src/fsipy/automatedPostprocessing/__init__.py
+++ b/src/fsipy/automatedPostprocessing/__init__.py
@@ -1,2 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+
 """Submodule for automated post-processing"""
+
+from . import log_plotter
+
+__all__ = [
+    "log_plotter",
+]

--- a/src/fsipy/automatedPreprocessing/__init__.py
+++ b/src/fsipy/automatedPreprocessing/__init__.py
@@ -1,3 +1,9 @@
 from . import automated_preprocessing
 from . import preprocessing_common
 from . import predeform_mesh
+
+__all__ = [
+    "automatedPreprocessing",
+    "preprocessing_common",
+    "predeform_mesh",
+]

--- a/src/fsipy/simulations/__init__.py
+++ b/src/fsipy/simulations/__init__.py
@@ -1,1 +1,5 @@
 from . import simulation_common
+
+__all__ = [
+    "simulation_common",
+]


### PR DESCRIPTION
The goal of this pull request is to prevent the unnecessary import of all submodules when importing a specific submodule (should fix issue #69).