### PR TITLE
Remove unuseful re-meshing test

### DIFF
--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -426,14 +426,6 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         assert mesh.GetNumberOfPoints() > 0, "No points in mesh, try to remesh."
         assert remeshed_surface.GetNumberOfPoints() > 0, "No points in surface mesh, try to remesh."
 
-        if mesh.GetNumberOfPoints() < remeshed_surface.GetNumberOfPoints():
-            print("--- An error occurred during meshing. Will attempt to re-mesh \n")
-            mesh, remeshed_surface = generate_mesh(distance_to_sphere,
-                                                   number_of_sublayers_fluid,
-                                                   number_of_sublayers_solid,
-                                                   solid_thickness,
-                                                   solid_thickness_parameters)
-
         if mesh_format in ("xml", "hdf5"):
             write_mesh(compress_mesh, file_name_surface_name, file_name_vtu_mesh, file_name_xml_mesh,
                        mesh, remeshed_surface)


### PR DESCRIPTION
This test for re-meshing was not useful, so removed. In many cases this only made the mesh generation run twice, but the resulting mesh was the same as before re-meshing.