### PR TITLE
Refactor scaling

### DIFF
--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -430,7 +430,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
                                                    solid_thickness,
                                                    solid_thickness_parameters)
         except Exception:
-            print("ERROR: Mesh generation failed. Try to remesh with alternative method.")
+            print("Trying to remesh with alternative method.")
             distance_to_sphere = mesh_alternative(distance_to_sphere)
             mesh, remeshed_surface = generate_mesh(distance_to_sphere,
                                                    number_of_sublayers_fluid,
@@ -764,7 +764,7 @@ def read_command_line(input_path=None):
                 mesh_format=args.mesh_format, flow_rate_factor=args.flow_rate_factor,
                 solid_side_wall_id=args.solid_side_wall_id, interface_fsi_id=args.interface_fsi_id,
                 solid_outer_wall_id=args.solid_outer_wall_id, fluid_volume_id=args.fluid_volume_id,
-                solid_volume_id=args.solid_volume_id)
+                solid_volume_id=args.solid_volume_id, verbosity=args.verbosity)
 
 
 def main_meshing():

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -123,6 +123,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
     # Scale surface
     if scale_factor is not None:
         surface = scale_surface(surface, scale_factor)
+        resampling_step *= scale_factor
 
     # Check if surface is closed and uncapps model if True
     is_capped = check_if_closed_surface(surface)

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -430,6 +430,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
                                                    solid_thickness,
                                                    solid_thickness_parameters)
         except Exception:
+            print("ERROR: Mesh generation failed. Try to remesh with alternative method.")
             distance_to_sphere = mesh_alternative(distance_to_sphere)
             mesh, remeshed_surface = generate_mesh(distance_to_sphere,
                                                    number_of_sublayers_fluid,

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -27,7 +27,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
                        meshing_method, refine_region, is_atrium, add_flow_extensions, visualize, config_path,
                        coarsening_factor, inlet_flow_extension_length, outlet_flow_extension_length,
                        number_of_sublayers_fluid, number_of_sublayers_solid, edge_length,
-                       region_points, compress_mesh, scale_factor, resampling_step, meshing_parameters,
+                       region_points, compress_mesh, scale_factor, scale_factor_h5, resampling_step, meshing_parameters,
                        remove_all, solid_thickness, solid_thickness_parameters, mesh_format, flow_rate_factor,
                        solid_side_wall_id, interface_fsi_id, solid_outer_wall_id, fluid_volume_id, solid_volume_id):
     """
@@ -453,7 +453,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
 
     if mesh_format == "hdf5":
         print("--- Converting XML mesh to HDF5\n")
-        convert_xml_mesh_to_hdf5(file_name_xml_mesh)
+        convert_xml_mesh_to_hdf5(file_name_xml_mesh, scale_factor_h5)
         # Evaluate edge length for inspection
         edge_length_evaluator(file_name_xml_mesh, file_name_edge_length_xdmf)
     elif mesh_format == "xdmf":
@@ -644,6 +644,12 @@ def read_command_line(input_path=None):
 
                         help="Scale input model by this factor. Used to scale model to [mm].")
 
+    parser.add_argument("-sch5", "--scale-factor-h5",
+                        default=1.0,
+                        type=float,
+                        help="Scaling factor for HDF5 mesh. Used to scale model to [mm]." +
+                             "Note that probes and other parameters are not scaled.")
+
     parser.add_argument('-rs', '--resampling-step',
                         default=0.1,
                         type=float,
@@ -734,8 +740,8 @@ def read_command_line(input_path=None):
                 number_of_sublayers_fluid=args.number_of_sublayers_fluid,
                 number_of_sublayers_solid=args.number_of_sublayers_solid, visualize=args.visualize,
                 region_points=args.region_points, compress_mesh=args.compress_mesh,
-                outlet_flow_extension_length=args.outlet_flowextension,
-                scale_factor=args.scale_factor, resampling_step=args.resampling_step,
+                outlet_flow_extension_length=args.outlet_flowextension, scale_factor=args.scale_factor,
+                scale_factor_h5=args.scale_factor_h5, resampling_step=args.resampling_step,
                 meshing_parameters=args.meshing_parameters, remove_all=args.remove_all,
                 solid_thickness=args.solid_thickness, solid_thickness_parameters=args.solid_thickness_parameters,
                 mesh_format=args.mesh_format, flow_rate_factor=args.flow_rate_factor,

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -440,6 +440,14 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         assert mesh.GetNumberOfPoints() > 0, "No points in mesh, try to remesh."
         assert remeshed_surface.GetNumberOfPoints() > 0, "No points in surface mesh, try to remesh."
 
+        if mesh.GetNumberOfPoints() < remeshed_surface.GetNumberOfPoints():
+            print("--- An error occurred during meshing. Will attempt to re-mesh \n")
+            mesh, remeshed_surface = generate_mesh(distance_to_sphere,
+                                                   number_of_sublayers_fluid,
+                                                   number_of_sublayers_solid,
+                                                   solid_thickness,
+                                                   solid_thickness_parameters)
+
         if mesh_format in ("xml", "hdf5"):
             write_mesh(compress_mesh, file_name_surface_name, file_name_vtu_mesh, file_name_xml_mesh,
                        mesh, remeshed_surface)

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -645,7 +645,8 @@ def read_command_line(input_path=None):
     parser.add_argument('-rs', '--resampling-step',
                         default=0.1,
                         type=float,
-                        help="Resampling step used to resample centerline in [m].")
+                        help="Resampling step used to resample centerline in [m]." +
+                             "Note: If --scale-factor is used, this step will be adjusted accordingly.")
 
     parser.add_argument('-mp', '--meshing-parameters',
                         type=float,

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -122,8 +122,10 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
 
     # Scale surface
     if scale_factor is not None:
+        print(f"--- Scale model by factor {scale_factor}\n")
         surface = scale_surface(surface, scale_factor)
         resampling_step *= scale_factor
+        solid_thickness_parameters = [scale_factor * i for i in solid_thickness_parameters]
 
     # Check if surface is closed and uncapps model if True
     is_capped = check_if_closed_surface(surface)
@@ -674,10 +676,11 @@ def read_command_line(input_path=None):
                         type=float,
                         nargs="+",
                         default=[0.3],
-                        help="Parameters for solid thickness. For constant solid thickness, this should be " +
+                        help="Parameters for solid thickness [m]. For constant solid thickness, this should be " +
                              "given as a single float. For 'variable' solid thickness, this should be given as " +
                              "four floats for the distancetosphere scaling function: 'offset', 'scale', 'min' " +
-                             "and 'max'. For example --solid-thickness-parameters 0 0.1 0.25 0.3")
+                             "and 'max'. For example --solid-thickness-parameters 0 0.1 0.25 0.3 " +
+                             "Note: If --scale-factor is used, solid thickness will be adjusted accordingly.")
 
     parser.add_argument('-mf', '--mesh-format',
                         type=str,

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -430,7 +430,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
                                                    solid_thickness,
                                                    solid_thickness_parameters)
         except Exception:
-            print("Trying to remesh with alternative method.")
+            print("ERROR: Mesh generation failed. Trying to remesh with alternative method.")
             distance_to_sphere = mesh_alternative(distance_to_sphere)
             mesh, remeshed_surface = generate_mesh(distance_to_sphere,
                                                    number_of_sublayers_fluid,
@@ -764,7 +764,7 @@ def read_command_line(input_path=None):
                 mesh_format=args.mesh_format, flow_rate_factor=args.flow_rate_factor,
                 solid_side_wall_id=args.solid_side_wall_id, interface_fsi_id=args.interface_fsi_id,
                 solid_outer_wall_id=args.solid_outer_wall_id, fluid_volume_id=args.fluid_volume_id,
-                solid_volume_id=args.solid_volume_id, verbosity=args.verbosity)
+                solid_volume_id=args.solid_volume_id)
 
 
 def main_meshing():

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -682,7 +682,9 @@ def read_command_line(input_path=None):
                         default=[0, 0.1, 0.4, 0.6],
                         help="Parameters for meshing method 'distancetospheres'. This should be given as " +
                              "four numbers for the distancetosphere scaling function: 'offset', 'scale', 'min' " +
-                             "and 'max'. For example --meshing-parameters 0 0.1 0.3 0.4")
+                             "and 'max'. For example --meshing-parameters 0 0.1 0.3 0.4" +
+                             "Note: If --scale-factor is used, 'offset', 'min', and 'max' parameters will be " +
+                             "adjusted accordingly.")
 
     remove_all = parser.add_mutually_exclusive_group(required=False)
     remove_all.add_argument('-ra', '--remove-all',
@@ -709,7 +711,7 @@ def read_command_line(input_path=None):
                              "Note: If --scale-factor is used, 'offset', 'min', and 'max' parameters will be " +
                              "adjusted accordingly for 'variable' solid thickness, and the constant value will also " +
                              "be scaled for 'constant' solid thickness.")
- 
+
     parser.add_argument('-mf', '--mesh-format',
                         type=str,
                         choices=["xml", "hdf5", "xdmf"],

--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -440,14 +440,6 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         assert mesh.GetNumberOfPoints() > 0, "No points in mesh, try to remesh."
         assert remeshed_surface.GetNumberOfPoints() > 0, "No points in surface mesh, try to remesh."
 
-        if mesh.GetNumberOfPoints() < remeshed_surface.GetNumberOfPoints():
-            print("--- An error occurred during meshing. Will attempt to re-mesh \n")
-            mesh, remeshed_surface = generate_mesh(distance_to_sphere,
-                                                   number_of_sublayers_fluid,
-                                                   number_of_sublayers_solid,
-                                                   solid_thickness,
-                                                   solid_thickness_parameters)
-
         if mesh_format in ("xml", "hdf5"):
             write_mesh(compress_mesh, file_name_surface_name, file_name_vtu_mesh, file_name_xml_mesh,
                        mesh, remeshed_surface)

--- a/src/fsipy/automatedPreprocessing/preprocessing_common.py
+++ b/src/fsipy/automatedPreprocessing/preprocessing_common.py
@@ -166,13 +166,15 @@ def generate_mesh(surface: vtkPolyData, number_of_sublayers_fluid: int, number_o
     return generated_mesh, remeshed_surface
 
 
-def convert_xml_mesh_to_hdf5(file_name_xml_mesh: str, scaling_factor: float = 0.001) -> None:
+def convert_xml_mesh_to_hdf5(file_name_xml_mesh: str, scaling_factor: float = 1) -> None:
     """Converts an XML mesh to an HDF5 mesh.
 
     Args:
         file_name_xml_mesh (str): The name of the XML mesh file.
         scaling_factor (float, optional): A scaling factor to apply to the mesh coordinates.
-                                          The default value is 0.001, which converts from millimeters to meters.
+                                          The default value is 1 (no scaling). Note that probes
+                                          and parameters inside _info.json file will not be scaled
+                                          if you only scale HDF5 file.
 
     Returns:
         None

--- a/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
+++ b/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
@@ -367,7 +367,6 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             tetgen.OutputSurfaceElements = 1
             tetgen.OutputVolumeElements = 1
             tetgen.RegionAttrib = 0
-            tetgen.Verbose = 1
             tetgen.Execute()
 
             if tetgen.Mesh.GetNumberOfCells() == 0 and surfaceToMesh.Mesh.GetNumberOfCells() > 0:

--- a/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
+++ b/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
@@ -367,10 +367,11 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             tetgen.OutputSurfaceElements = 1
             tetgen.OutputVolumeElements = 1
             tetgen.RegionAttrib = 0
+            tetgen.Verbose = 1
             tetgen.Execute()
 
             if tetgen.Mesh.GetNumberOfCells() == 0 and surfaceToMesh.Mesh.GetNumberOfCells() > 0:
-                self.PrintLog('An error occurred during tetrahedralization. Will only output ' +
+                raise Exception('An error occurred during tetrahedralization. Will only output ' +
                               'surface mesh and boundary layer.')
 
             self.PrintLog("Assembling fluid mesh")
@@ -459,8 +460,8 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             self.Mesh = tetgen.Mesh
 
             if self.Mesh.GetNumberOfCells() == 0 and surfaceToMesh.Mesh.GetNumberOfCells() > 0:
-                self.PrintLog('An error occurred during tetrahedralization. Will only output surface mesh.')
                 self.Mesh = surfaceToMesh.Mesh
+                raise Exception('An error occurred during tetrahedralization. Will only output surface mesh.')
 
         if self.Tetrahedralize:
 

--- a/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
+++ b/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
@@ -372,7 +372,7 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
 
             if tetgen.Mesh.GetNumberOfCells() == 0 and surfaceToMesh.Mesh.GetNumberOfCells() > 0:
                 raise Exception('An error occurred during tetrahedralization. Will only output ' +
-                              'surface mesh and boundary layer.')
+                                'surface mesh and boundary layer.')
 
             self.PrintLog("Assembling fluid mesh")
             appendFilter = vtkvmtk.vtkvmtkAppendFilter()

--- a/tests/test_simulation_common.py
+++ b/tests/test_simulation_common.py
@@ -171,7 +171,7 @@ def test_print_mesh_summary(temporary_hdf5_file):
 
     # Get the captured output as a string
     printed_summary = captured_output.getvalue()
-    print(printed_summary)
+
     # Define expected summary strings
     expected_strings = [
         "=== Mesh Information Summary ===",

--- a/tests/test_simulation_common.py
+++ b/tests/test_simulation_common.py
@@ -171,21 +171,21 @@ def test_print_mesh_summary(temporary_hdf5_file):
 
     # Get the captured output as a string
     printed_summary = captured_output.getvalue()
-
+    print(printed_summary)
     # Define expected summary strings
     expected_strings = [
         "=== Mesh Information Summary ===",
-        "X range: 0.029932 to 0.0368581 (delta: 0.0069)",
-        "Y range: 0.0287532 to 0.034399700000000005 (delta: 0.0056)",
-        "Z range: 0.0381364 to 0.0447481 (delta: 0.0066)",
+        "X range: 29.932 to 36.8581 (delta: 6.9261)",
+        "Y range: 28.7532 to 34.3997 (delta: 5.6465)",
+        "Z range: 38.1364 to 44.7481 (delta: 6.6117)",
         "Number of cells: 32283",
         "Number of cells per processor: 32283",
         "Number of edges: 0",
         "Number of faces: 65699",
         "Number of facets: 65699",
         "Number of vertices: 5860",
-        "Volume: 6.956489929680826e-08",
-        "Number of cells per volume: 464070247011.501",
+        "Volume: 69.56489929680801",
+        "Number of cells per volume: 464.07024701150266",
     ]
 
     # Check if each expected summary string is present in the printed output


### PR DESCRIPTION
We had scaling from mm to m as a default when converting from xml to HDF5 while probes and other information inside `_info.json` file were not scaled. This PR changes default scaling to 1 (no scaling) and that the user should scale the input surface at the beginning of meshing so that probes are generated with scaled surface. 