### PR TITLE
remove solid thickness paramter sclaing duplicate

### DIFF
--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -125,7 +125,6 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         print(f"--- Scale model by factor {scale_factor}\n")
         surface = scale_surface(surface, scale_factor)
         resampling_step *= scale_factor
-        solid_thickness_parameters = [scale_factor * i for i in solid_thickness_parameters]
 
     # Check if surface is closed and uncapps model if True
     is_capped = check_if_closed_surface(surface)


### PR DESCRIPTION
In #77, I forgot to remove scaling of `solid_thickness_parameters` and it should be removed as there’s correct scaling happening later in the code 

https://github.com/KVSlab/Aneurysm_Workflow_FSI/blob/e5faff2870d02eb580ee73d36f371258b3f4cf99/src/fsipy/automatedPreprocessing/automated_preprocessing.py#L398-L400