### PR TITLE
Retry mesh generation on TetGen failures

### DIFF
--- a/src/fsipy/automatedPreprocessing/automated_preprocessing.py
+++ b/src/fsipy/automatedPreprocessing/automated_preprocessing.py
@@ -505,7 +505,7 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         edge_length_evaluator(file_name_xdmf_mesh, file_name_edge_length_xdmf)
 
     network, probe_points = setup_model_network(centerlines, file_name_probe_points, region_center, verbose_print,
-                                                has_outlet, has_multiple_inlets)
+                                                has_multiple_inlets)
 
     # Load updated parameters following meshing
     parameters = get_parameters(base_path)

--- a/src/fsipy/automatedPreprocessing/preprocessing_common.py
+++ b/src/fsipy/automatedPreprocessing/preprocessing_common.py
@@ -130,6 +130,7 @@ def generate_mesh(surface: vtkPolyData, number_of_sublayers_fluid: int, number_o
     meshGenerator.ElementSizeMode = "edgelengtharray"  # Variable size mesh
     meshGenerator.TargetEdgeLengthArrayName = "Size"  # Variable size mesh
     meshGenerator.LogOn = 1
+    meshGenerator.ExitOnError = 0
     meshGenerator.BoundaryLayer = 1
     meshGenerator.NumberOfSubLayersSolid = number_of_sublayers_fluid
     meshGenerator.NumberOfSubLayersFluid = number_of_sublayers_solid

--- a/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
+++ b/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
@@ -370,7 +370,7 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             tetgen.Execute()
 
             if tetgen.Mesh.GetNumberOfCells() == 0 and surfaceToMesh.Mesh.GetNumberOfCells() > 0:
-                self.PrintError('Running TetGen failed. Try to remesh.')
+                self.PrintError('Running TetGen failed. Try to re-mesh.')
 
             self.PrintLog("Assembling fluid mesh")
             appendFilter = vtkvmtk.vtkvmtkAppendFilter()

--- a/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
+++ b/src/fsipy/automatedPreprocessing/vmtkmeshgeneratorfsi.py
@@ -370,8 +370,7 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             tetgen.Execute()
 
             if tetgen.Mesh.GetNumberOfCells() == 0 and surfaceToMesh.Mesh.GetNumberOfCells() > 0:
-                raise Exception('An error occurred during tetrahedralization. Will only output ' +
-                                'surface mesh and boundary layer.')
+                self.PrintError('Running TetGen failed. Try to remesh.')
 
             self.PrintLog("Assembling fluid mesh")
             appendFilter = vtkvmtk.vtkvmtkAppendFilter()


### PR DESCRIPTION
This PR adds an option `--mesh-generation-retries` to control how many mesh generation retries to run on TetGen failures.