### PR TITLE
added yaml for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: '6.1.0'
+    hooks:
+      - id: flake8
+        exclude: ^postprocessing_h5py/|^postprocessing_fenics/
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+      - id: mypy
+        exclude: ^postprocessing_h5py/|^postprocessing_fenics/


### PR DESCRIPTION
Fix #105 

pre-commit is a nice framework to automatically run linters before commit. With this config file, once you install pre-commit, it will run `flake8` and `mypy`, and stop the commit if it has problem with those two. 

After installing pre-commit with conda or pip, you just run ` pre-commit install` and it should be all set. 

https://pre-commit.com/#install